### PR TITLE
Fix bitmap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(name="trollbufr",
                    "Programming Language :: Python :: 2",
                    "Programming Language :: Python :: 2.6",
                    "Programming Language :: Python :: 2.7",
-                   "Topic :: Scientific/Engineering",
-                   "Topic :: Scientific/Engineering :: Geo-Science"],
+                   "Topic :: Scientific/Engineering"
+                   ],
       test_suite="bufr.tests.suite",
       entry_points={
           "console_scripts": ["trollbufr = trollbufr.bufr_main:run",

--- a/trollbufr/coder/operator.py
+++ b/trollbufr/coder/operator.py
@@ -341,13 +341,13 @@ def fun_36_r(subset, descr):
         # Bitmap not as replication, but explicit 031031-list in sect3.
         am = 1
         an = 0
-        loc_di = subset._di
-        while subset._dl[loc_di] == 31031:
+        while subset._dl[subset._di] == 31031:
             # Count 031031.
             an += 1
-            loc_di += 1
-        # Set descriptor index to last of the 031031.
-        subset._di=loc_di-1
+            subset._di += 1
+        else:
+            # Set descriptor index to last of the 031031.
+            subset._di -= 1
     if am != 1 or subset._dl[subset._di] != 31031:
         raise BufrDecodeError("Fault in replication defining bitmap!")
     if subset._as_array:
@@ -397,9 +397,9 @@ def fun_37_w(subset, descr):
     if descr == 237000:
         if ((subset.is_compressed
                  and isinstance(subset._vl[0][subset._vi], (list, tuple)))
-                or
-                (not subset.is_compressed
-                 and isinstance(subset._vl[subset._vi], (list, tuple)))
+                    or
+                    (not subset.is_compressed
+                     and isinstance(subset._vl[subset._vi], (list, tuple)))
                 ):
             subset._vi += 1
         subset._backref_record.reset()

--- a/trollbufr/coder/operator.py
+++ b/trollbufr/coder/operator.py
@@ -334,7 +334,20 @@ def fun_36_r(subset, descr):
     """Define data present bit-map."""
     # Evaluate following replication descr.
     subset._di += 1
-    am, an, _ = subset.eval_loop_descr(record=False)
+    if fun.descr_is_loop(subset._dl[subset._di]):
+        # How bitmaps should be done.
+        am, an, _ = subset.eval_loop_descr(record=False)
+    elif subset._dl[subset._di] == 31031:
+        # Bitmap not as replication, but explicit 031031-list in sect3.
+        am = 1
+        an = 0
+        loc_di = subset._di
+        while subset._dl[loc_di] == 31031:
+            # Count 031031.
+            an += 1
+            loc_di += 1
+        # Set descriptor index to last of the 031031.
+        subset._di=loc_di-1
     if am != 1 or subset._dl[subset._di] != 31031:
         raise BufrDecodeError("Fault in replication defining bitmap!")
     if subset._as_array:
@@ -384,9 +397,9 @@ def fun_37_w(subset, descr):
     if descr == 237000:
         if ((subset.is_compressed
                  and isinstance(subset._vl[0][subset._vi], (list, tuple)))
-                    or
-                    (not subset.is_compressed
-                     and isinstance(subset._vl[subset._vi], (list, tuple)))
+                or
+                (not subset.is_compressed
+                 and isinstance(subset._vl[subset._vi], (list, tuple)))
                 ):
             subset._vi += 1
         subset._backref_record.reset()


### PR DESCRIPTION
RSKL creates BUFR with explicitly listed bitmap in Sect. 3 contraire WMO-306 94.5.5.3, but trollbufr might decode such.