### PR TITLE
Remove outdated note that Python3 support is TODO

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,6 @@ To-Do
 -----
 There are still things to do:
 
-- Support Python3
 - Implement the remaining obscure operators
 
 So, get involved at PyTroll_ or GitHub_!


### PR DESCRIPTION
The TODO section in the main documentation still noted that Python 3
support was still TODO.  Howewer, #21 added Python 3 support, so this
notice can be removed.