### PR TITLE
Include "short name" from eccodes-tables in table lookup.

### DIFF
--- a/trollbufr/bufr_main.py
+++ b/trollbufr/bufr_main.py
@@ -267,7 +267,7 @@ def run(argv=None):
                                 )
         parser.add_argument('-V', '--version',
                             action='version',
-                            version="pybufr %s" % program_version
+                            version="TrollBUFR %s" % program_version
                             )
         parser.add_argument("-v", "--verbose", dest="verbose",
                             action="count",

--- a/trollbufr/bufr_main.py
+++ b/trollbufr/bufr_main.py
@@ -108,38 +108,40 @@ def read_bufr_data(args):
                                       end="", file=fh_out)
                                 print(file=fh_out)
                                 continue
-                            d_name, d_unit, d_typ = tabl.lookup_elem(descr_entry.descr)
-                            if d_typ in (TabBType.CODE, TabBType.FLAG):
+                            descr_info = tabl.lookup_elem(descr_entry.descr)
+                            if descr_info.type in (TabBType.CODE, TabBType.FLAG):
                                 if descr_entry.value is None:
                                     print("%06d %-40s = Missing value"
-                                          % (descr_entry.descr, d_name), file=fh_out)
+                                          % (descr_entry.descr, descr_info.name), file=fh_out)
                                 else:
                                     v = tabl.lookup_codeflag(descr_entry.descr,
                                                              descr_entry.value)
                                     print("%06d %-40s = %s"
                                           % (descr_entry.descr,
-                                             d_name,
+                                             descr_info.name,
                                              str(v)), file=fh_out)
                             else:
-                                if d_unit in ("CCITT IA5", "Numeric"):
-                                    d_unit = ""
+                                if descr_info.unit in ("CCITT IA5", "Numeric"):
+                                    dinf_unit = ""
+                                else:
+                                    dinf_unit = descr_info.unit
                                 if descr_entry.value is None:
                                     print("%06d %-40s = /// %s"
                                           % (descr_entry.descr,
-                                             d_name, d_unit), file=fh_out)
+                                             descr_info.name, dinf_unit), file=fh_out)
                                 elif descr_entry.quality is not None:
                                     print("%06d %-40s = %s %s (%s)"
                                           % (descr_entry.descr,
-                                             d_name,
+                                             descr_info.name,
                                              str(descr_entry.value),
-                                             d_unit,
+                                             dinf_unit,
                                              descr_entry.quality), file=fh_out)
                                 else:
                                     print("%06d %-40s = %s %s"
                                           % (descr_entry.descr,
-                                             d_name,
+                                             descr_info.name,
                                              str(descr_entry.value),
-                                             d_unit), file=fh_out)
+                                             dinf_unit), file=fh_out)
             except Exception as e:
                 print("ERROR\t%s" % e, file=fh_out)
                 if logger.isEnabledFor(logging.DEBUG):

--- a/trollbufr/coder/bufr_types.py
+++ b/trollbufr/coder/bufr_types.py
@@ -49,6 +49,9 @@ BMP USE  : Re-use the previously defined data present bit-map. Same as "BMP DEF"
 LOC desc : Local descriptor skipped, its bit-width was declared by operator.
 """
 
+DescrInfoEntry = namedtuple("DescrInfoEntry", "name shortname unit type")
+"""From table-B lookup for textual output."""
+
 BufrMetadataKeys = ("master",  # BUFR master version, WMO=0.
                     "center",  # Originating center.
                     "subcenter",  # Originating sub-center.
@@ -149,7 +152,7 @@ class BackrefRecord(object):
     def __next__(self):
         """Return next descriptor/alter pair from stack."""
         if self._stack_idx >= len(self._backref_stack):
-            #raise StopIteration # XXX:
+            # raise StopIteration # XXX:
             return
         r = self._backref_stack[self._stack_idx]
         self._stack_idx += 1

--- a/trollbufr/coder/tables.py
+++ b/trollbufr/coder/tables.py
@@ -27,7 +27,7 @@ Created on Sep 15, 2016
 
 @author: amaul
 '''
-from .bufr_types import TabBType
+from .bufr_types import TabBType, DescrInfoEntry
 
 import logging
 logger = logging.getLogger("trollbufr")
@@ -97,25 +97,24 @@ class Tables(object):
         return sval or "N/A"
 
     def lookup_elem(self, descr):
-        """Returns name, unit, and type associated with table B or C descriptor."""
+        """Returns name, short-name, unit, and type in a named tuple
+        associated with table B or C descriptor.
+        """
         if descr < 100000:
             b = self.tab_b.get(descr)
             if b is None:
-                return ("UNKN", "", None)
-            if b.abbrev is not None:
-                return (b.abbrev, b.unit, b.typ)
-            else:
-                return (b.full_name, b.unit, b.typ)
+                return DescrInfoEntry("UNKN", None, "", None)
+            return DescrInfoEntry(b.full_name, b.abbrev, b.unit, b.typ)
         elif 200000 < descr < 300000:
             if descr in self.tab_c:
                 c = self.tab_c.get(descr)
             else:
                 c = self.tab_c.get(descr // 1000)
             if c is None:
-                return ("UNKN", "", "oper")
-            return (c[0], "", "oper")
+                return DescrInfoEntry("UNKN", None, "", "oper")
+            return DescrInfoEntry(c[0], None, "", "oper")
         else:
-            return (None, None, None)
+            return DescrInfoEntry(None, None, None, None)
 
     def lookup_common(self, val):
         """Returns meaning for data category value."""

--- a/trollbufr/version.py
+++ b/trollbufr/version.py
@@ -25,7 +25,7 @@ Ported to Py3  09/2018
 """
 
 __major__ = "0"
-__minor__ = "10"
-__patch__ = "3"
+__minor__ = "11"
+__patch__ = "0"
 
 version = ".".join([__major__, __minor__, __patch__])


### PR DESCRIPTION
Change return value of table-B-lookup from tuple to named-tuple.
This encapsulates the lookup return value and gives "access by
attribute".